### PR TITLE
Editable install needed for stubgen

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,5 +59,6 @@ jobs:
               run: |
                   mypy pypict example
                   mypy --allow-untyped-defs tests
+                  pip install -v -e .
                   bash stubgen.sh
                   [[ $(git diff | wc -l) == 0 ]]


### PR DESCRIPTION
This is needed as `stubgen` fails otherwise.